### PR TITLE
example for VSI on Classic

### DIFF
--- a/examples/classic/.gitignore
+++ b/examples/classic/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+*.backup
+.terraform/
+terraform.tfvars
+.terraform/
+*.tfstate
+.terraform.lock.hcl
+id_rsa*

--- a/examples/classic/README.md
+++ b/examples/classic/README.md
@@ -1,0 +1,75 @@
+# Provision a Virtual Server Instance on Classic Infrastructure
+
+## Introduction
+
+This set of simple example Terraform scripts demonstrates how to provision a Centos 7 Virtual Server Instance (VSI) on IBM Cloud Classic Infrastructure.
+
+### Prerequisites
+
+* Terraform version `0.14` or higher -  see installation instructions in the reference section:  [Terraform installation](#terraform-installation)
+* (Optional for this scenario, but needed by most) IBM API Key - refer to  [IBM Cloud Doc: Setting up an API key](https://cloud.ibm.com/docs/account?topic=account-userapikey#create_user_key)
+* Create or find your IBM Cloud Classic Infrastructure API key [here](https://cloud.ibm.com/iam/apikeys). Select `Classic Infrastructure API Keys` option from view dropdown.
+* For your Classic Infrastructure user name go to [Users](https://cloud.ibm.com/iam/users), Click on `user`. Find user name in the `VPN password` section under `User Details` tab.
+
+
+
+### Input Variables
+
+
+We recommend using `terraform.tfvars` to provide values to the input parameters to the example scripts, and include it in your `.gitignore`, instead of filling them in directly in `variables.tf`. Either copy your existing `terraform.tfvars` into the `examples/WireGuard` directory and edit it to include all the required parameters, or copy from the sample `terraform.tfvars.template` into a new `terraform.tfvars` configuration file and populate it.
+
+
+| Name | Description | Type | Default/Example | Required |
+| ---- | ----------- | ---- | ------- | -------- |
+| ibmcloud_api_key | API Key needed to provision most IBM Cloud resources.  Your key must be authorized to perform the actions in the your script. | string | N/A | no (included for demo purpose)|
+| iaas_classic_username | Classic Infrastructure user name used to provision resources. | string | N/A | yes |
+| iaas_classic_api_key | IBM Cloud Classic Infrastructure API key used to provision Classic Infrastructure resources. | string | N/A | yes |
+| hostname | Hostname for the new VSI. | string | "user123" | yes |
+| region | The region to provision the VSI in. | string | "us-south" | yes |
+| zone | Zone in which to provision all resources.  Must be in the same region as the vpc. | string | "us-south-1" | yes |
+| ssh_key | The public SSH key you want to use to access the VSI. |string | N/A | yes |
+
+
+## Terraform Version
+Tested with Terraform v0.14 and v1.0.5.
+
+## Running the configuration
+
+Run:
+
+```shell
+terraform init
+```
+
+```shell
+terraform apply
+```
+
+Once the scripts finish successfully (takes ~3 minutes in our test), key attributes of the new VSI including the public IP address are printed to standard out. You can log on to the VSI using the SSH key you provided driving provisioning.
+
+To delete the VSI instance, Run
+
+Run:
+
+```shell
+terraform destroy
+```
+
+### Terraform installation
+
+* set up a directory to store terraform binary with `mkdir terraform && cd terraform`
+* download the `Terraform CLI` from the [hashicorp site](https://www.terraform.io/downloads.html) (or directly from the [directory](https://releases.hashicorp.com/terraform/) to the local directory. e.g. `wget https://releases.hashicorp.com/terraform/0.14.8/terraform_0.14.8_linux_amd64.zip`) and unzip it.
+* set up the `$PATH` environment variable to point to `terraform` executable: `export PATH=$PATH:$HOME/terraform`
+* verify the installation
+
+  ```
+  # terraform -version
+  Terraform v1.0.5
+
+  ```
+
+### References
+
+* [IBM Cloud Doc: Getting started with Terraform on IBM Cloud](https://cloud.ibm.com/docs/ibm-cloud-provider-for-terraform?topic=ibm-cloud-provider-for-terraform-getting-started)
+* [IBM Cloud Provider Documentation](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs)
+  * [IBM Cloud Provider Documentation - Authentication (API keys etc)](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs#authentication)

--- a/examples/classic/main.tf
+++ b/examples/classic/main.tf
@@ -1,0 +1,29 @@
+
+provider "ibm" {
+  ibmcloud_api_key = var.ibmcloud_api_key
+  iaas_classic_username = var.iaas_classic_username
+  iaas_classic_api_key = var.iaas_classic_api_key
+  region           = var.region
+}
+
+resource "ibm_compute_ssh_key" "vm_ssh_key" {
+    label = "${var.ssh_key.label}"
+    notes = "test_ssh_key_notes"
+    public_key = "${var.ssh_key.public_key}"
+}
+
+resource "ibm_compute_vm_instance" "twc_terraform_sample" {
+  hostname                   = "${var.hostname}"
+  domain                     = "${var.domain}"
+  os_reference_code          = "CENTOS_7_64"
+  datacenter                 = "dal13"
+  network_speed              = 10
+  hourly_billing             = true
+  private_network_only       = false
+  cores                      = 1
+  memory                     = 1024
+  disks                      = [25, 10, 20]
+  ssh_key_ids                = [ibm_compute_ssh_key.vm_ssh_key.id]
+  dedicated_acct_host_only   = true
+  local_disk                 = false
+}

--- a/examples/classic/outputs.tf
+++ b/examples/classic/outputs.tf
@@ -1,0 +1,20 @@
+output "id" {
+  value = ibm_compute_vm_instance.twc_terraform_sample.id
+}
+output "domain" {
+  value = ibm_compute_vm_instance.twc_terraform_sample.domain
+}
+output "hostname" {
+  value = ibm_compute_vm_instance.twc_terraform_sample.hostname
+}
+
+output "public_ip_address" {
+  value = ibm_compute_vm_instance.twc_terraform_sample.ipv4_address
+}
+output "private_ip_address" {
+  value = ibm_compute_vm_instance.twc_terraform_sample.ipv4_address_private
+}
+
+output "memory" {
+  value = ibm_compute_vm_instance.twc_terraform_sample.memory
+}

--- a/examples/classic/terraform.tfvars.template
+++ b/examples/classic/terraform.tfvars.template
@@ -1,0 +1,17 @@
+//  fill in or overwrite the default for the variables
+
+// optional
+ibmcloud_api_key = "dummy"
+
+// must provide for classic infrastructure provisioning
+iaas_classic_username =
+iaas_classic_api_key =
+
+//must have for this VSI provisioning sample
+domain =
+hostname =
+// defaults to us-south
+region =  "us-south"
+// Zone in which to provision vsi.  This must be in the same region as the vsi
+zone =  "us-south-1"
+ssh_key = { "label" : "key-name", "public_key" : "something-like-ssh-rsa-xxxx"}

--- a/examples/classic/variables.tf
+++ b/examples/classic/variables.tf
@@ -1,0 +1,32 @@
+
+// IBM Cloud credentials
+variable "ibmcloud_api_key" {
+	description = "provide your IBM Cloud API Key."
+}
+variable "iaas_classic_username" {
+	description = "provide your IBM Cloud Classic Infrastructure user name."
+}
+variable "iaas_classic_api_key" {
+	description = "provide your IBM Cloud Classic Infrastructure API Key/"
+}
+
+// VSI provisioning parameters
+variable "region" {
+  description = "Target region of the new VSI."
+}
+variable "zone" {
+  description = "Zone in which to provision the VSI."
+}
+variable "domain" {
+  description = "domain for the new VSI."
+}
+variable "hostname" {
+  description = "hostname for the new VSI."
+}
+variable "ssh_key" {
+  type = object({
+    label = string
+    public_key = string
+  })
+  description = "the public key info to ssh to the VSI"
+}

--- a/examples/classic/versions.tf
+++ b/examples/classic/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+      version = ">= 1.29.0"
+    }
+  }
+  required_version = ">= 0.14"
+}


### PR DESCRIPTION
Here is a very simple sample for provisioning VSI on classic, under the directory `examples/classic`, as requested by a client. I've tested it running.  

Could you give it a quick review @ileneruth , and merge it to master if it makes sense to you? Another option is just leave it at the current branch, and refer the one customer there directly, if we want to keep the repo/master on VPC GEN 2 etc...

Thanks! 

 